### PR TITLE
Add Mailer Toggle to toggle.el

### DIFF
--- a/toggle.el
+++ b/toggle.el
@@ -85,6 +85,7 @@
                 ("app/helpers/\\1.rb"     . "spec/helpers/\\1_spec.rb")))
     (rails   . (("app/controllers/\\1.rb" . "test/functional/\\1_test.rb")
                 ("app/models/\\1.rb"      . "test/unit/\\1_test.rb")
+                ("app/mailers/\\1.rb"     . "test/mailers/\\1_test.rb")
                 ("lib/\\1.rb"             . "test/unit/test_\\1.rb")))
     (ruby    . (("lib/\\1.rb"             . "test/test_\\1.rb")
                 ("\\1.rb"                 . "test_\\1.rb")))


### PR DESCRIPTION
Add mailer support to the Rails toggles.

This could also be done with a wildcard matcher for all `app/*` paths versus `test/*` paths, but that's probably a matter of opinion on intended behavior.
